### PR TITLE
Add Logging requirements to V1 (Ecosystem)

### DIFF
--- a/en/V1-IoT_Ecosystem_Requirements.md
+++ b/en/V1-IoT_Ecosystem_Requirements.md
@@ -63,7 +63,7 @@ To ensure the security of all software produced, the build process for the syste
 | # | Description | L1 | L2 | L3 |
 | -- | ---------------------- | - | - | - |
 | **1.4.1** | Verify that devices can collect logs about events with security implications, such as successful and failed authentication attempts, access to debugging functionality etc. | | ✓ | ✓ |
-| **1.4.2** | Verify that collected logs have adequate granularity to enable actionable insights and alerts. They should include, at a minimum, the type of event, timestamp, source, outcome and identify of involved actors. | | ✓ | ✓ |
+| **1.4.2** | Verify that collected logs have the adequate granularity to enable actionable insights and alerts. Logs should include, at a minimum, the type of event, timestamp, source, outcome, and identification of involved actors. | | ✓ | ✓ |
 | **1.4.3** | Verify that devices contain or are synchronized with a reliable time source, to ensure the validity of log timestamps. | | ✓ | ✓ |
 | **1.4.4** | Verify that collected logs do not include sensitive information, such as PII, credentials and cryptographic keys. | | ✓ | ✓ |
 | **1.4.5** | Verify that collected logs can be securely retrieved from the devices over an online collection, either periodically or on-demand. | | ✓ | ✓ |

--- a/en/V1-IoT_Ecosystem_Requirements.md
+++ b/en/V1-IoT_Ecosystem_Requirements.md
@@ -64,10 +64,10 @@ To ensure the security of all software produced, the build process for the syste
 | -- | ---------------------- | - | - | - |
 | **1.4.1** | Verify that devices can collect logs about events with security implications, such as successful and failed authentication attempts, access to debugging functionality etc. | | ✓ | ✓ |
 | **1.4.2** | Verify that collected logs have adequate granularity to enable actionable insights and alerts. They should include, at a minimum, the type of event, timestamp, source, outcome and identify of involved actors. | | ✓ | ✓ |
-| **1.4.3** | Verify that devices contain or are synchronized with a reliable time source, to ensure tha validity of log timestamps. | | ✓ | ✓ |
+| **1.4.3** | Verify that devices contain or are synchronized with a reliable time source, to ensure the validity of log timestamps. | | ✓ | ✓ |
 | **1.4.4** | Verify that collected logs do not include sensitive information, such as PII, credentials and cryptographic keys. | | ✓ | ✓ |
-| **1.4.5** | Verify that collected logs can be securely retrieved from the devices over an online collection, either periodically or on-demand. | ✓ | ✓ | ✓ |
-| **1.4.6** | Verify that collected logs are preserved for the amount of time required by organizational policies and that they are safely deleted when the retention period is over | | ✓ | ✓ |
+| **1.4.5** | Verify that collected logs can be securely retrieved from the devices over an online collection, either periodically or on-demand. | | ✓ | ✓ |
+| **1.4.6** | Verify that collected logs are preserved for the amount of time required by organizational policies and that they are safely deleted when the retention period is over. | | ✓ | ✓ |
 | **1.4.7** | Verify that the confidentiality, integrity and authenticity of collected logs is appropriately protected, both on the devices that created them and on other systems that store or process them. | | ✓ | ✓ |
 
 ## References

--- a/en/V1-IoT_Ecosystem_Requirements.md
+++ b/en/V1-IoT_Ecosystem_Requirements.md
@@ -58,6 +58,18 @@ To ensure the security of all software produced, the build process for the syste
 | **1.3.14** | Verify that debug information does not contain sensitive information, such as PII, credentials or cryptographic material. | ✓ | ✓ | ✓ |
 | **1.3.15** | Verify that embedded applications are not susceptible to OS command injection by performing input validation and escaping of parameters within firmware code, shell command wrappers, and scripts. | ✓ | ✓ | ✓ |
 
+### Logging
+
+| # | Description | L1 | L2 | L3 |
+| -- | ---------------------- | - | - | - |
+| **1.4.1** | Verify that devices can collect logs about events with security implications, such as successful and failed authentication attempts, access to debugging functionality etc. | | ✓ | ✓ |
+| **1.4.2** | Verify that collected logs have adequate granularity to enable actionable insights and alerts. They should include, at a minimum, the type of event, timestamp, source, outcome and identify of involved actors. | | ✓ | ✓ |
+| **1.4.3** | Verify that devices contain or are synchronized with a reliable time source, to ensure tha validity of log timestamps. | | ✓ | ✓ |
+| **1.4.4** | Verify that collected logs do not include sensitive information, such as PII, credentials and cryptographic keys. | | ✓ | ✓ |
+| **1.4.5** | Verify that collected logs can be securely retrieved from the devices over an online collection, either periodically or on-demand. | ✓ | ✓ | ✓ |
+| **1.4.6** | Verify that collected logs are preserved for the amount of time required by organizational policies and that they are safely deleted when the retention period is over | | ✓ | ✓ |
+| **1.4.7** | Verify that the confidentiality, integrity and authenticity of collected logs is appropriately protected, both on the devices that created them and on other systems that store or process them. | | ✓ | ✓ |
+
 ## References
 For more information, see also:
 
@@ -70,3 +82,4 @@ For more information, see also:
 - Microsoft SDL: <https://www.microsoft.com/en-us/sdl/>
 - OWASP C-based Toolchain Hardening Cheat Sheet: <https://cheatsheetseries.owasp.org/cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.html>
 - OWASP Embedded Application Security: <https://owasp.org/www-project-embedded-application-security/>
+- NIST Draft NISTIR 8259D: <https://nvlpubs.nist.gov/nistpubs/ir/2020/NIST.IR.8259D-draft.pdf>


### PR DESCRIPTION
Partially fixes #25 by including a Logging category in V1. Requirements are aligned with the latest NIST draft on IoT profiles (8259D). 