### PR TITLE
Build workflow fixes

### DIFF
--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -40,7 +40,7 @@ jobs:
         path: tools/OWASP_ISVS-SNAPSHOT.xml
 
     - name: Generate English PDF
-      run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc iowaspisvs/isvs-docgenerator:latest '/pandoc_makedocs.sh en SNAPSHOT'
+      run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc owaspisvs/isvs-docgenerator:latest '/pandoc_makedocs.sh en SNAPSHOT'
     - name: Upload English PDF
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -11,11 +11,11 @@ jobs:
       with:
         fetch-depth: 1
 
-    #- name: Pull the Docker image
-    #  run: docker pull owasp/masvs-docgenerator:0.2
+    - name: Pull the Docker image
+      run: docker pull owaspisvs/isvs-docgenerator:latest
     # only use below when testing new container builds
-    - name: Build the Docker image
-      run: docker build ./tools/docker --tag isvs-generator:latest
+    # - name: Build the Docker image
+    #  run: docker build ./tools/docker --tag isvs-generator:latest
 
     - name: Generate python scripts (csv)
       run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format csv --lang en > OWASP_ISVS-SNAPSHOT.csv'

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -18,11 +18,11 @@ jobs:
     #  run: docker build ./tools/docker --tag isvs-generator:latest
 
     - name: Generate python scripts (csv)
-      run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format csv --lang en > OWASP_ISVS-SNAPSHOT.csv'
+      run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format csv --lang en > OWASP_ISVS-SNAPSHOT.csv'
     - name: Generate python scripts (json)
-      run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format json --lang en > OWASP_ISVS-SNAPSHOT.json'
+      run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format json --lang en > OWASP_ISVS-SNAPSHOT.json'
     - name: Generate python scripts (xml)
-      run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format xml --lang en > OWASP_ISVS-SNAPSHOT.xml'
+      run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format xml --lang en > OWASP_ISVS-SNAPSHOT.xml'
     - name: Upload CSV export
       uses: actions/upload-artifact@v1
       with:
@@ -40,7 +40,7 @@ jobs:
         path: tools/OWASP_ISVS-SNAPSHOT.xml
 
     - name: Generate English PDF
-      run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc isvs-generator:latest '/pandoc_makedocs.sh en SNAPSHOT'
+      run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc iowaspisvs/isvs-docgenerator:latest '/pandoc_makedocs.sh en SNAPSHOT'
     - name: Upload English PDF
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/GITHUB_REFs
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    - '*' # Push events to matching *, i.e. 1.0, 20.15.10
 
 name: Upload Release Asset
 jobs:
@@ -18,17 +18,17 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Build the Docker image
-        run: docker build ./tools/docker --tag isvs-generator:latest
+      - name: Pull the Docker image
+        run: docker pull owaspisvs/isvs-docgenerator:latest
       - name: Generate python scripts (csv)
-        run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format csv --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.csv'
+        run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format csv --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.csv'
       - name: Generate python scripts (json)
-        run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format json --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.json'
+        run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format json --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.json'
       - name: Generate python scripts (xml)
-        run: docker run -v ${PWD}:/documents isvs-generator:latest 'cd /documents/tools && python3 export.py --format xml --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.xml'
+        run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format xml --lang en > OWASP_ISVS-${{ steps.get_version.outputs.VERSION }}.xml'
 
       - name: Generate English docs
-        run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc isvs-generator:latest '/pandoc_makedocs.sh en ${{ steps.get_version.outputs.VERSION }}'
+        run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc owaspisvs/isvs-docgenerator:latest '/pandoc_makedocs.sh en ${{ steps.get_version.outputs.VERSION }}'
       - name: Release
         uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
- Fixed the failing build workflows. The Docker image is no longer built locally on every run, but pulled from the owaspisvs Docker hub repo. 
- Updated the release workflow to match any tag, since the ISVS release versions are not prefixed by "v"

Note: the Docker file will still eventually need fixing (one of the dependencies used is broken). This is not an issue for now because the Docker image hosted on Docker is the last working version.