### PR TITLE
Adds Zigbee requirements in V4.

### DIFF
--- a/en/V4-Communication_Requirements.md
+++ b/en/V4-Communication_Requirements.md
@@ -52,6 +52,18 @@ Devices use network communication to exchange data and receive commands within t
 | **4.4.3** | Verify that in case WPA is used, it is used with AES encryption (CCMP mode). | ✓ | ✓ | ✓ |
 | **4.4.4** | Verify that Wi-Fi Protected Setup (WPS) is not used to establish Wi-Fi connections between devices. | ✓ | ✓ | ✓ |
 
+### Zigbee 
+
+| # | Description | L1 | L2 | L3 |
+| --  | ---------------------- | - | - | - |
+| **4.5.1** | Verify that Zigbee version 3.0 is used for new applications. | ✓ | ✓ | ✓ |
+| **4.5.2** | Verify that a suitable Zigbee security architecture (Centralized or Distributed) is selected, depending on the application's security level requirements and threat model. The Centralized architecture generally offers higher security at the cost of flexibility. | ✓ | ✓ | ✓ |
+| **4.5.3** | Verify that the most secure way of joining the Zigbee network is used, depending on the selected security architecture. For example, for the Centralized architecture, use out-of-band install codes. For the Distributed one, use pre-configured link keys. | ✓ | ✓ | ✓ |
+| **4.5.4** | Verify that the default pre-configured global link key (ZigbeeAlliance09) is not used to join the network, except if explicitly required for compatibility reasons and if associated risks have been taken into account. | ✓ | ✓ | ✓ |
+| **4.5.5** | Verify that user interaction is required to activate pairing mode for both the joining nodes and the Zigbee Trust Center / router. Devices should automatically exit pairing mode after a pre-defined short amount of time, even if pairing is unsuccessful. | ✓ | ✓ | ✓ |
+| **4.5.6** | Verify that the network key is randomly generated (for example during the initial network setup). | ✓ | ✓ | ✓ |
+| **4.5.7** | Verify that the network key is periodically rotated. |   |   | ✓ |
+| **4.5.8** | Verify that users can obtain an overview of paired devices to validate that they are legitimate (for example, by comparing the MAC addresses of connected devices to the expected ones). |   |   | ✓ |
 
 ## References
 For more information, see also:
@@ -61,3 +73,4 @@ For more information, see also:
 - IETF RFC 7525 - Recommendations for Secure Use of TLS and DTLS: <https://tools.ietf.org/html/rfc7525>
 - NIST SP800-121r2 - Guide to Bluetooth Security: <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-121r2.pdf>
 - NIST SP800-97 - Establishing Wireless Robust Security Networks: <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-97.pdf>
+- HKCERT - ZigBee Security Study: <https://www.hkcert.org/f/blog/264453/3a1c8eed-012c-4b59-9d9e-971001d66c77-DLFE-14602.pdf>


### PR DESCRIPTION
Since the conversation in https://github.com/OWASP/IoT-Security-Verification-Standard-ISVS/pull/77 died off, I'm submitting a fresh pull with the proposed Zigbee requirements :) 

Sources: 
* This MIT paper, which is used as a Zigbee reference by the ENISA guidelines: https://courses.csail.mit.edu/6.857/2017/project/17.pdf [1]
* The Zigbee alliance technical presentation: https://zigbeealliance.org/wp-content/uploads/zip/zigbee-technical-presentation.zip [2]
* This 2020 study by HKCert, which also includes some recommendations on pg. 15: https://www.hkcert.org/f/blog/264453/3a1c8eed-012c-4b59-9d9e-971001d66c77-DLFE-14602.pdf [3]

Rationale:
* 4.5.1:  According to [1] Zigbee 3.0 is safer than older versions such as Zigbee 1.2 (HA), amongst others because it supports out-of-band ways of providing the key used when joining the network to the TC.
* 4.5.2: According to [1], the Centralized architecture is more suitable to higher security environments, because it supports install codes for joining the network.
* 4.5.3: As explained in [1] in a lot of detail, a crucial part of Zigbee security is how devices join the network and learn the network key. For Centralized architectures, the safest way to do this is using an install code (ex. QR code on packaging of sensor), which is pre-installed in the sensor and transmitted out-of-band to the TC. For Distributed architectures, the safest way is to use pre-installed link keys, which should be manufacturer or application specific (i.e. not the known global link key "ZigbeeAlliance09").
* 4.5.4: See above.
* 4.5.5: As mentioned in [3], to reduce the attack surface of the system, devices (both joining nodes and the TC / router) should only enter pairing mode with user interaction.
* 4.5.6: As noted in [3], the network key is known by all devices in the Zigbee network, some implementations use the same across different systems, which is a security risk.
* 4.5.7: Periodic network key rotation lowers the risk in case of compromise (the network key is known by all devices in the Zigbee network), and also answers some concerns about long-term reuse of the same key for AES encryption, as noted in [3] (pg. 15) and [1].
* 4.5.8: Adapted from [3] and proposed as an alternative to MAC address whitelisting - gives users the power to inspect their network for malicious Zigbee devices.