### PR TITLE
Adds LoRaWAN requirements in V4

### DIFF
--- a/en/V4-Communication_Requirements.md
+++ b/en/V4-Communication_Requirements.md
@@ -52,6 +52,17 @@ Devices use network communication to exchange data and receive commands within t
 | **4.4.3** | Verify that in case WPA is used, it is used with AES encryption (CCMP mode). | ✓ | ✓ | ✓ |
 | **4.4.4** | Verify that Wi-Fi Protected Setup (WPS) is not used to establish Wi-Fi connections between devices. | ✓ | ✓ | ✓ |
 
+### LoRaWAN
+
+| # | Description | L1 | L2 | L3 |
+| --  | ---------------------- | - | - | - |
+| **4.5.1** | Verify that LoRaWAN version 1.1 is used by new applications. | ✓ | ✓ | ✓ |
+| **4.5.2** | Verify that the network, join and application servers of the LoRaWAN ecosystem are appropriately hardened according to industry best practices and benchmarks. | ✓ | ✓ | ✓ |
+| **4.5.3** | Verify that all communication between the LoRaWAN gateway and the network, join and application servers occurs over a secure channel (for example TLS or IPSec), guaranteeing at least the integrity and authenticity of the messages.  | ✓ | ✓ | ✓ |
+| **4.5.4** | Verify that root keys are unique per end device. | ✓ | ✓ | ✓ |
+| **4.5.5** | Verify that an appropriate response strategy is in place in case an end device's root keys are compromised, given that root keys cannot be remotely updated.  |   | ✓ | ✓ |
+| **4.5.6** | Verify that replay attacks are not possible using off-sequence frame counters. For example, in case end device counters are reset after a reboot, verify that old messages cannot be replayed to the gateway.  |   | ✓ | ✓ |
+| **4.5.7** | Verify that the LoRaWAN gateway is capable of detecting jamming attempts and can alert the user or system administrator in case of ongoing jamming attacks.  |   | ✓ | ✓ |
 
 ## References
 For more information, see also:
@@ -61,3 +72,4 @@ For more information, see also:
 - IETF RFC 7525 - Recommendations for Secure Use of TLS and DTLS: <https://tools.ietf.org/html/rfc7525>
 - NIST SP800-121r2 - Guide to Bluetooth Security: <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-121r2.pdf>
 - NIST SP800-97 - Establishing Wireless Robust Security Networks: <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-97.pdf>
+- A systematic review of security in LoRaWAN: <https://arxiv.org/pdf/2105.00384.pdf> 

--- a/en/V4-Communication_Requirements.md
+++ b/en/V4-Communication_Requirements.md
@@ -58,11 +58,9 @@ Devices use network communication to exchange data and receive commands within t
 | --  | ---------------------- | - | - | - |
 | **4.5.1** | Verify that LoRaWAN version 1.1 is used by new applications. | ✓ | ✓ | ✓ |
 | **4.5.2** | Verify that the network, join and application servers of the LoRaWAN ecosystem are appropriately hardened according to industry best practices and benchmarks. | ✓ | ✓ | ✓ |
-| **4.5.3** | Verify that all communication between the LoRaWAN gateway and the network, join and application servers occurs over a secure channel (for example TLS or IPSec), guaranteeing at least the integrity and authenticity of the messages.  | ✓ | ✓ | ✓ |
+| **4.5.3** | Verify that all communication between the LoRaWAN gateway and the network, join and application servers occurs over a secure channel (for example TLS or IPsec), guaranteeing at least the integrity and authenticity of the messages.  | ✓ | ✓ | ✓ |
 | **4.5.4** | Verify that root keys are unique per end device. | ✓ | ✓ | ✓ |
-| **4.5.5** | Verify that an appropriate response strategy is in place in case an end device's root keys are compromised, given that root keys cannot be remotely updated.  |   | ✓ | ✓ |
-| **4.5.6** | Verify that replay attacks are not possible using off-sequence frame counters. For example, in case end device counters are reset after a reboot, verify that old messages cannot be replayed to the gateway.  |   | ✓ | ✓ |
-| **4.5.7** | Verify that the LoRaWAN gateway is capable of detecting jamming attempts and can alert the user or system administrator in case of ongoing jamming attacks.  |   | ✓ | ✓ |
+| **4.5.5** | Verify that replay attacks are not possible using off-sequence frame counters. For example, in case end device counters are reset after a reboot, verify that old messages cannot be replayed to the gateway.  |   | ✓ | ✓ |
 
 ## References
 For more information, see also:


### PR DESCRIPTION
Hi :) I've made a first attempt to add requirements for LoRaWAN, to resolve #81 . I couldn't find a single authoritative source (ex. NIST or ENISA guidelines), so I've based them on the sources below. 

Sources:
* \[1\]: Selective jamming of LoRaWAN using commodity hardware: <https://arxiv.org/pdf/1712.02141.pdf> 
* \[2\]: A systematic review of security in LoRaWAN (2021): <https://arxiv.org/pdf/2105.00384.pdf> 
* \[3\]: Exploring The Security Vulnerabilities of LoRa: <https://lirias.kuleuven.be/retrieve/460994>
* \[4\]: LoRaWAN 1.1 specification: <https://lora-alliance.org/wp-content/uploads/2020/11/lorawantm_specification_-v1.1.pdf>
* \[5\]: LoRaWAN is secure but implementation matters: <https://lora-alliance.org/resource_hub/lorawan-is-secure-but-implementation-matters/>

Rationale:
* 4.5.1: Version 1.0 has a number of known vulnerabilities that have been addressed in v1.1 (\[1\]).
* 4.5.2: The backend servers are considered as trusted by the LoraWAN spec. Compromise of those servers can lead to a widespread compromise in the LoraWAN ecosystem (\[5\]). 
* 4.5.3: The integrity of LoRaWAN messages is not end-to-end verified (not between network server & backend), therefore MITM attacks are possible if the channel does not guarantee message integrity. The LoRaWAN payloads are end-to-end encrypted. See discussion in \[2\], "A lack of end-to-end integrity protection" 
* 4.5.4: The LoRaWAN spec imposes that to reduce the impact in case of device compromise (\[4\]).
* 4.5.5: Since OTA firmware udpates are not possible, compromised devices can only be recovered with physical access (see \[2\], point "The key update is not specified").
* 4.5.6: This is a concern explored in \[3\], handling of off-sequence frame counters is left to the app and the developer.  
* 4.5.7: As noted in \[1\], jamming LoRaWAN networks is easy and practical, therefore for L2 and L3 applications the gateway should be able to detect and alert when that happens.