### PR TITLE
Fix numbering in V4-Communication_Requirements.md

### DIFF
--- a/en/V4-Communication_Requirements.md
+++ b/en/V4-Communication_Requirements.md
@@ -69,11 +69,11 @@ Devices use network communication to exchange data and receive commands within t
 
 | # | Description | L1 | L2 | L3 |
 | --  | ---------------------- | - | - | - |
-| **4.5.1** | Verify that LoRaWAN version 1.1 is used by new applications. | ✓ | ✓ | ✓ |
-| **4.5.2** | Verify that the network, join and application servers of the LoRaWAN ecosystem are appropriately hardened according to industry best practices and benchmarks. | ✓ | ✓ | ✓ |
-| **4.5.3** | Verify that all communication between the LoRaWAN gateway and the network, join and application servers occurs over a secure channel (for example TLS or IPsec), guaranteeing at least the integrity and authenticity of the messages.  | ✓ | ✓ | ✓ |
-| **4.5.4** | Verify that root keys are unique per end device. | ✓ | ✓ | ✓ |
-| **4.5.5** | Verify that replay attacks are not possible using off-sequence frame counters. For example, in case end device counters are reset after a reboot, verify that old messages cannot be replayed to the gateway.  |   | ✓ | ✓ |
+| **4.6.1** | Verify that LoRaWAN version 1.1 is used by new applications. | ✓ | ✓ | ✓ |
+| **4.6.2** | Verify that the network, join and application servers of the LoRaWAN ecosystem are appropriately hardened according to industry best practices and benchmarks. | ✓ | ✓ | ✓ |
+| **4.6.3** | Verify that all communication between the LoRaWAN gateway and the network, join and application servers occurs over a secure channel (for example TLS or IPsec), guaranteeing at least the integrity and authenticity of the messages.  | ✓ | ✓ | ✓ |
+| **4.6.4** | Verify that root keys are unique per end device. | ✓ | ✓ | ✓ |
+| **4.6.5** | Verify that replay attacks are not possible using off-sequence frame counters. For example, in case end device counters are reset after a reboot, verify that old messages cannot be replayed to the gateway.  |   | ✓ | ✓ |
 
 ## References
 For more information, see also:


### PR DESCRIPTION
Fixes numbering of LoRaWAN requirements: updated from 4.5.x to 4.6.x, since 4.5.x are attributed to ZigBee.