### PR TITLE
Fix V2.1.12: remove CAPTCHA as brute force mitigation example

### DIFF
--- a/en/V2-User_Space_Application_Requirements.md
+++ b/en/V2-User_Space_Application_Requirements.md
@@ -33,7 +33,7 @@ Many controls in this chapter are implemented through cryptography. Therefore, a
 | **2.1.9** | Verify that authentication credentials for users, devices, or services are not hardcoded in firmware or ecosystem applications. | ✓ | ✓ | ✓ |
 | **2.1.10** | Verify that provisioned credentials for device authentication are unique per device. | ✓ | ✓ | ✓ |
 | **2.1.11** | Verify that authentication schemes are designed to revoke credentials of compromised or decommissioned devices. | | | ✓ |
-| **2.1.12** | Verify that authentication mechanisms have sufficient protection against brute force attacks (e.g., account lockout, rate limiting, exponential backoff, or CAPTCHA). | ✓ | ✓ | ✓ |
+| **2.1.12** | Verify that authentication mechanisms have sufficient protection against brute force attacks (e.g., account lockout, rate limiting, or exponential backoff). | ✓ | ✓ | ✓ |
 | **2.1.13** | Verify that reauthentication of users and devices is required at regular intervals appropriate to the security criticality of the application or functionality. | | ✓ | ✓ |
 
 ### Authorization


### PR DESCRIPTION
## Summary

- Removes `CAPTCHA` from the V2.1.12 brute force protection examples

## Rationale

CAPTCHA is a human-in-the-loop browser mechanism not applicable to IoT device authentication flows, which are typically M2M, API/CLI-based, or running on constrained hardware with no rendering capability. Web management interfaces (e.g., router admin panels) are a distinct surface better addressed by OWASP ASVS.

The remaining examples (account lockout, rate limiting, exponential backoff) are accurate and sufficient for the IoT context.

## Test plan

- [ ] Verify V2.1.12 text no longer references CAPTCHA
- [ ] Confirm `tools/export.py` parses the updated requirement correctly

Closes #101