### PR TITLE
Fix CI: upgrade deprecated actions/upload-artifact@v1 and checkout@v1

### DIFF
--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
 
@@ -24,17 +24,17 @@ jobs:
     - name: Generate python scripts (xml)
       run: docker run -v ${PWD}:/documents owaspisvs/isvs-docgenerator:latest 'cd /documents/tools && python3 export.py --format xml --lang en > OWASP_ISVS-SNAPSHOT.xml'
     - name: Upload CSV export
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT.csv
         path: tools/OWASP_ISVS-SNAPSHOT.csv
     - name: Upload JSON export
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT.json
         path: tools/OWASP_ISVS-SNAPSHOT.json
     - name: Upload XML export
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT.xml
         path: tools/OWASP_ISVS-SNAPSHOT.xml
@@ -42,23 +42,23 @@ jobs:
     - name: Generate English PDF
       run: docker run --rm -u `id -u`:`id -g` -v ${PWD}:/pandoc owaspisvs/isvs-docgenerator:latest '/pandoc_makedocs.sh en SNAPSHOT'
     - name: Upload English PDF
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT-en.pdf
         path: OWASP_ISVS-SNAPSHOT-en.pdf
     - name: Upload English EPUB
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT-en.epub
         path: OWASP_ISVS-SNAPSHOT-en.epub
     - name: Upload English DOCX
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: OWASP_ISVS-SNAPSHOT-en_WIP_.docx
         path: OWASP_ISVS-SNAPSHOT-en_WIP_.docx
     #  MOBI cannot be generated for now
     #- name: Upload English MOBI
-    #  uses: actions/upload-artifact@v1
+    #  uses: actions/upload-artifact@v4
     #  with:
     #    name: OWASP_ISVS-SNAPSHOT-en.mobi
     #    path: OWASP_ISVS-SNAPSHOT-en.mobi


### PR DESCRIPTION
## Summary

The `Document Build` workflow failed on **every** push (4/4 runs in history, all dying at "Set up job") because GitHub auto-fails any workflow referencing the deprecated `actions/upload-artifact@v1`. This put a permanent red X on all pushes and on open PRs such as #103.

## Changes

- `actions/upload-artifact@v1` → `@v4` (all 6 upload steps)
- `actions/checkout@v1` → `@v4` (Node 12 EOL)

Each artifact already has a unique `name`, so v4's unique-name-per-run constraint is satisfied — no other changes needed.

## Verification

This branch's run is the **first ever successful run** of the Document Build workflow — all steps green, including the docker generation and pandoc PDF/EPUB/DOCX steps that had never executed before (the job previously died at setup).

Closes #104