### PR TITLE
Fix Pages deploy: use modern bundler (Ruby 3.2 dropped untaint)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
+          bundler: latest
           bundler-cache: true
 
       - name: Setup Pages


### PR DESCRIPTION
## Problem
The first real run of `pages.yml` (after master became bleeding-edge) failed at **Setup Ruby**:

```
undefined method 'untaint' for String (NoMethodError)  — bundler-1.17.2
```

`Gemfile.lock` pins **bundler 1.17.2**, which calls `String#untaint` — a method **removed in Ruby 3.2** (the version `ruby/setup-ruby` installs). The `deploy` job never ran (needs `build`), so the live site did not update.

## Fix
Add `bundler: latest` to the Setup Ruby step so a modern bundler is installed, overriding the stale lockfile pin. One line; no lockfile churn.

## Validation
`pages.yml` only runs on push to `master`, so this PR can't exercise it directly — the real proof is the post-merge Pages run going green and the live site updating (with the RC banner). Fallback if it still fails: pin `ruby-version` to `3.1` (still has `untaint`).

Refs #109