### PR TITLE
Fix Pages deploy: bump bundler to 2.5.6 in Gemfile.lock

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-          bundler: latest
           bundler-cache: true
 
       - name: Setup Pages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   wdm (~> 0.1)
 
 BUNDLED WITH
-   1.17.2
+   2.5.6


### PR DESCRIPTION
## Problem
PR #110 (`bundler: latest`) did **not** fix the Pages build. A modern bundler reads the lockfile's `BUNDLED WITH 1.17.2` and **self-downgrades back to 1.17.2** ("Installing Bundler 1.17.2 and restarting using that version"), which then crashes on `String#untaint` — removed in Ruby 3.2.

## Fix
Update the lockfile itself: `BUNDLED WITH 1.17.2` → `2.5.6` (bundler 2.5.x requires Ruby >= 3.0, confirmed working on 3.2), and revert the now-unnecessary `bundler: latest` workflow override. This is the canonical fix for this error.

## Validation
`pages.yml` only runs on push to `master`, so the real proof is the post-merge Pages run going green and the live site deploying (with the RC banner). Fallback if anything else surfaces: pin `ruby-version` to `3.1`.

Refs #109