### PR TITLE
Fix unstyled site: use just-the-docs gem theme instead of remote_theme

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,6 +1,6 @@
 title: OWASP IoT Security Verification Standard
 description: The OWASP ISVS provides comprehensive security requirements for IoT ecosystems and their components
-remote_theme: just-the-docs/just-the-docs@v0.8.2
+theme: just-the-docs
 
 # GitHub Pages settings
 baseurl: "/IoT-Security-Verification-Standard-ISVS"


### PR DESCRIPTION
## Problem
After the first successful Pages deploy, the live site rendered **completely unstyled** — no theme CSS, no `<title>`, no navigation. The HTML contained only our content.

Root cause: `_config.yaml` used `remote_theme: just-the-docs/...`, which requires the **`jekyll-remote-theme` plugin** — absent from both the Gemfile and the `plugins:` list. Jekyll silently ignored the directive and built with no theme. (Never surfaced before because the Pages build had never succeeded until today.)

## Fix
The `just-the-docs` gem is already a locked dependency (`Gemfile` + `Gemfile.lock`), so switch `remote_theme:` → `theme: just-the-docs`. The workflow build (`bundle exec jekyll build`) applies the gem theme directly. No new dependency.

## Validation
`pages.yml` runs only on push to `master`, so the real proof is the post-merge deploy: the live site should render **styled** (just-the-docs layout, nav, search). Will verify after merge and flag any further theme touch-ups (logo path, nav) now that styling is visible.

Refs #109