### PR TITLE
Fix release workflow: replace deprecated set-output and checkout@v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
       - name: Pull the Docker image
         run: docker pull owaspisvs/isvs-docgenerator:latest
       - name: Generate python scripts (csv)


### PR DESCRIPTION
## Problem
`release.yaml` (triggered on tag push) has two deprecated-action issues that would break the `1.0.0-RC2` build:
- **`::set-output`** (line 20) — disabled by GitHub. The version is derived here and used in every artifact filename; if it returns empty, artifacts become `OWASP_ISVS-.pdf` etc. and the release is malformed.
- **`actions/checkout@v2`** (line 15) — deprecated.

## Fix
- `::set-output` → `echo "VERSION=..." >> $GITHUB_OUTPUT` (GitHub's documented replacement).
- `checkout@v2` → `@v4`.

## Validation
`release.yaml` only runs on a **tag push**, so this PR can't exercise it; the required `build` (docgen) check is unrelated and will pass. The real proof is the `1.0.0-RC2` tag build (Workstream E) producing correctly named artifacts. This is Workstream A on #109 — the last hard pre-tag blocker.

Refs #109