### PR TITLE
Fix site rendering: Appendix B layout + V1 Supply Chain table

### DIFF
--- a/en/Appendix_B-Compliance_Mapping.md
+++ b/en/Appendix_B-Compliance_Mapping.md
@@ -1,5 +1,5 @@
 ---
-layout: col-document
+layout: default
 title: Appendix B - Compliance Mapping
 nav_order: 7
 ---

--- a/en/V1-IoT_Ecosystem_Requirements.md
+++ b/en/V1-IoT_Ecosystem_Requirements.md
@@ -37,6 +37,7 @@ A defined and openly communicated support lifecycle is equally important. By est
 
 
 ### Supply Chain
+
 | # | Description | L1 | L2 | L3 |
 | -- | ---------------------- | - | - | - |
 | **1.2.1** | Verify that each application (including firmware) in the ecosystem maintains a software bill of materials (SBOM) cataloging third-party components, versioning, and published vulnerabilities. | ✓ | ✓ | ✓ |


### PR DESCRIPTION
Workstream I.1/I.2 (#109). Two rendering bugs visible on the live RC site:

- **I.1 Appendix B unstyled.** `en/Appendix_B-Compliance_Mapping.md` used `layout: col-document` — not a layout in the just-the-docs theme (build warning: "Layout 'col-document' ... does not exist"), so the page rendered with no theme/nav. Switched to `layout: default` (matches every other page).
- **I.2 V1 Supply Chain table rendered as raw text.** The `### Supply Chain` heading was immediately followed by the table with no blank line; kramdown requires a blank line before a table. Added it.

Post-merge Pages deploy will be verified on the live site. (I.3 — Appendix B's 9-column Table 1 overflow — checked next once it renders in the proper layout.)

Refs #109