### PR TITLE
Fix site layout: order Appendix B after Appendix A, widen content area

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,15 @@
+// Custom style overrides for the OWASP ISVS documentation site.
+// just-the-docs imports this file (_sass/custom/custom.scss) after the theme,
+// so rules here override the theme defaults.
+
+// Widen the main content area on large screens.
+// The just-the-docs default caps `.main` at 50rem (~800px), which leaves a
+// large empty band on wide displays and cramps the wide compliance-mapping
+// tables in Appendix B. 64rem (~1024px) uses more of the viewport while
+// keeping prose line-lengths readable. Adjust this single value to taste
+// (e.g. 72rem / 80rem for wider, or `none` for full-width).
+@media (min-width: 50rem) {
+  .main {
+    max-width: 64rem;
+  }
+}

--- a/en/Appendix_B-Compliance_Mapping.md
+++ b/en/Appendix_B-Compliance_Mapping.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Appendix B - Compliance Mapping
-nav_order: 7
+nav_order: 10
 ---
 
 # Appendix B: Compliance Mapping


### PR DESCRIPTION
Workstream I.5/I.6 (#109). Verified in a local containerized Jekyll build (Ruby 3.2, our Gemfile) before pushing.

- **Nav order:** Appendix B had `nav_order: 7`, colliding with V4 and placing it before V4/V5 and before Appendix A. Set to `10` so it follows Appendix A. (Verified: nav tail now …V5 → Appendix A → Appendix B.)
- **Content width:** added `_sass/custom/custom.scss` widening `.main` from the just-the-docs 50rem (~800px) cap to 64rem on large screens — less empty space on wide displays, more room for the wide Appendix B tables. (Verified: `max-width: 64rem` compiles into the served CSS.)

Width is a single tunable value in `custom.scss`. Post-merge Pages deploy will confirm on the live site.

Refs #109